### PR TITLE
Finish up element history

### DIFF
--- a/src/js/client/actions/CampaignElementActions.js
+++ b/src/js/client/actions/CampaignElementActions.js
@@ -34,13 +34,14 @@ export default {
             });
     },
     update(project, element) {
-        campaignElementService
+        return campaignElementService
             .update(project, element)
             .then(() => {
                 dispatch({
                     actionType: AppConstants.UPDATE_ELEMENT,
                     element: element
                 });
+                return true;
             });
     }
 };

--- a/src/js/client/components/elements/ElementPage.js
+++ b/src/js/client/components/elements/ElementPage.js
@@ -55,7 +55,10 @@ export default class ElementPage extends React.Component {
     _onSave() {
         let element = this.state.element;
         element.content = this.state.content;
-        CampaignElementActions.update(this.props.params.id, element);
+        CampaignElementActions.update(this.props.params.id, element)
+            .then(() => {
+                HistoryActions.findForElement(this.props.params.id, this.props.params.elementId);
+            });
         this.setState({edit: false});
     }
     _onCancel() {

--- a/src/js/client/components/elements/ElementPage.js
+++ b/src/js/client/components/elements/ElementPage.js
@@ -67,6 +67,15 @@ export default class ElementPage extends React.Component {
             content: this.state.element.content
         });
     }
+
+    showHistory(history) {
+        return () => {
+            this.setState({
+                historical: (_.find(history.changes, { field: 'content' }) || {}).after || ' '
+            });
+        }
+    }
+
     getYoutubeId(url) {
         var regExp = /^.*(youtu.be\/|v\/|u\/\w\/|embed\/|watch\?v=|\&v=)([^#\&\?]*).*/;
         var match = url.match(regExp);
@@ -78,10 +87,50 @@ export default class ElementPage extends React.Component {
     }
 
     renderContent() {
-        let content = this.state.content || this.state.element.content || '';
+        let content = this.state.historical || this.state.content || this.state.element.content || '';
+
+        let clearAndCancel = (
+            <div className="right-align">
+                <button
+                        className="btn-flat tiny white green-text"
+                        type="button"
+                        onClick={this._onSave}
+                        style={{marginRight: '40px'}}>
+                    <i className="material-icons right">save</i>
+                    Save
+                </button>
+                <button
+                        className="btn-flat tiny white red-text"
+                        type="button"
+                        onClick={this._onCancel}>
+                    <i className="material-icons right">clear</i>
+                    Cancel
+                </button>
+            </div>
+        );
+        let saveButton = (
+            <button
+                type="button"
+                className="btn-flat blue-grey lighten-2 white-text"
+                onClick={() => {this.setState({edit:true});}}
+                style={{padding: '0 15px', fontSize: '12px'}}>
+                <i className="material-icons right">edit</i>Change
+            </button>
+        );
+        if (this.state.historical) {
+            saveButton = (
+                <button
+                        className="btn-flat tiny white red-text"
+                        type="button"
+                        onClick={() => {this.setState({historical:null});}}>
+                    <i className="material-icons right">clear</i>
+                    Back To Current
+                </button>
+            );
+        }
 
         if (this.state.element.type === 'blog') {
-            if (this.state.edit) {
+            if (this.state.edit && !this.state.historical) {
                 return (
                     <div className="">
                         <InputTextArea
@@ -89,23 +138,7 @@ export default class ElementPage extends React.Component {
                             val={content}
                             onChange={this._onContentChange}
                         />
-                        <div className="right-align">
-                            <button
-                                className="btn-flat tiny white green-text"
-                                type="button"
-                                onClick={this._onSave}
-                                style={{marginRight: '40px'}}>
-                                <i className="material-icons right">save</i>
-                                Save
-                            </button>
-                            <button
-                                className="btn-flat tiny white red-text"
-                                type="button"
-                                onClick={this._onCancel}>
-                                <i className="material-icons right">clear</i>
-                                Cancel
-                            </button>
-                        </div>
+                        {clearAndCancel}
                     </div>
                 );
             }
@@ -118,13 +151,7 @@ export default class ElementPage extends React.Component {
                         {tmp}
                     </div>
                     <div className="right-align">
-                        <button
-                            type="button"
-                            className="btn-flat blue-grey lighten-2 white-text"
-                            onClick={() => {this.setState({edit:true});}}
-                            style={{padding: '0 15px', fontSize: '12px'}}>
-                            <i className="material-icons right">edit</i>Change
-                        </button>
+                        {saveButton}
                     </div>
                 </div>
             );
@@ -149,7 +176,7 @@ export default class ElementPage extends React.Component {
                     </div>
                 );
             }
-            if (this.state.edit) {
+            if (this.state.edit && !this.state.historical) {
                 return (
                     <div>
                         <div style={{marginBottom: '20px', borderBottom: '1px solid rgba(0,0,0,0.1)'}}>
@@ -160,23 +187,7 @@ export default class ElementPage extends React.Component {
                             val={content}
                             onChange={this._onContentChange}
                         />
-                        <div className="right-align">
-                            <button
-                                className="btn-flat tiny white green-text"
-                                type="button"
-                                onClick={this._onSave}
-                                style={{marginRight: '40px'}}>
-                                <i className="material-icons right">save</i>
-                                Save
-                            </button>
-                            <button
-                                className="btn-flat tiny white red-text"
-                                type="button"
-                                onClick={this._onCancel}>
-                                <i className="material-icons right">clear</i>
-                                Cancel
-                            </button>
-                        </div>
+                        {clearAndCancel}
                     </div>
                 );
             }
@@ -186,19 +197,12 @@ export default class ElementPage extends React.Component {
                     {_content}
                     </div>
                     <div className="right-align">
-                        <button
-                            type="button"
-                            className="btn-flat blue-grey lighten-2 white-text"
-                            onClick={() => {this.setState({edit:true});}}
-                            style={{padding: '0 15px', fontSize: '12px'}}>
-                            <i className="material-icons right">edit</i>Change
-                        </button>
+                        {saveButton}
                     </div>
                 </div>
             );
         }
         if (this.state.element.type === 'photo') {
-            console.log(this.state.element);
             return (
                 <div>
                     Images
@@ -215,12 +219,12 @@ export default class ElementPage extends React.Component {
                 <p>Loading element...</p>
             );
         }
-        console.log(this.state);
         let history = '';
+        let self = this;
         if (this.state.history) {
             history = this.state.history.map((obj) => {
                 return (
-                    <li key={obj._id} className="collection-item">
+                    <li key={obj._id} className="collection-item" onClick={self.showHistory(obj)}>
                         <span className="teal-text" style={{fontSize: '12px'}}>{obj.created_by.name.first} {obj.created_by.name.last}</span><br />
                         <div>{moment(obj.created_at).format('MMM DD, YYYY')}
                             <p className="secondary-content grey-text text-darken-2" style={{margin:'0'}}>

--- a/src/js/server/controllers/base_controller.js
+++ b/src/js/server/controllers/base_controller.js
@@ -35,7 +35,13 @@ export default function(service, middleware_name, extensions) {
          * folks from overriding roles, user auth data, etc.
          */
         sanitize: function(obj) {
-            return obj;
+            delete obj._id;
+            delete obj.__v;
+            delete obj.created_by;
+            delete obj.updated_by;
+            delete obj.created;
+            delete obj.updated;
+            return _.extend({}, obj);
         },
         /**
          * Retrieves the entitiy indicated by the clientId request parameter.

--- a/src/js/server/models/_auditing.js
+++ b/src/js/server/models/_auditing.js
@@ -67,7 +67,7 @@ module.exports = exports = function auditingPlugin(schema) {
     });
 
     schema.post('save', function(doc, next){
-        var ignoreList = ['__v','__id'];
+        var ignoreList = ['__v','__id','created','updated','created_by','updated_by'];
 
         var before = this._original;
         if (before instanceof mongoose.Model) {

--- a/src/js/server/services/HistoryService.js
+++ b/src/js/server/services/HistoryService.js
@@ -11,9 +11,10 @@ export default {
      * Retrieve a list of audit events for the given entity type and id.
      * @param opts
      */
-    list(opts) {
+    list(opts, sort) {
         return History
             .find(opts || {})
+            .sort(sort || { created_at: -1 })
             .populate('created_by')
             .populateHistoryTarget()
             .exec();

--- a/src/js/server/services/base_service.js
+++ b/src/js/server/services/base_service.js
@@ -57,7 +57,9 @@ export default (model, extensions) => {
          * @param entity The representation of the entity to update
          */
         update(entity, modified) {
-            _.extend(entity, modified);
+            Object.keys(modified).forEach((key) => {
+                entity[key] = modified[key];
+            });
             return entity.savePromise();
         },
 


### PR DESCRIPTION
- Element history now refreshes immediately upon element update
- Element history is now clickable
- Cleaned up some code duplication while I was at it
- Auditing fields are no longer tracked by history, and ObjectId-type fields are tracked solely by the id they contain rather than the entire object if one is specified.
